### PR TITLE
Update Podfiles to match the latest SDK

### DIFF
--- a/Sample App SSO/Podfile
+++ b/Sample App SSO/Podfile
@@ -12,12 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/circlefin/w3s-ios-sdk.git'
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '13.0'
 
 target 'w3s-ios-sample-app-wallets' do
   # Comment the next line if you don't want to use dynamic frameworks
-  use_frameworks! :linkage => :static
+  use_frameworks!
+
+  # Applicable before CircleProgrammableWalletSDK version 1.0.12
+  # use_frameworks! :linkage => :static
 
   pod 'CircleProgrammableWalletSDK'
 
@@ -27,6 +31,9 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+
+      # See this: https://developer.apple.com/forums/thread/725300
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
     end
   end
 end

--- a/Sample App/Podfile
+++ b/Sample App/Podfile
@@ -13,12 +13,15 @@
 #  limitations under the License.
 
 source 'https://github.com/circlefin/w3s-ios-sdk.git'
-source 'https://cdn.cocoapods.org/'
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '13.0'
 
 target 'w3s-ios-sample-app-wallets' do
   # Comment the next line if you don't want to use dynamic frameworks
-  use_frameworks! :linkage => :static
+  use_frameworks!
+
+  # Applicable before CircleProgrammableWalletSDK version 1.0.12
+  # use_frameworks! :linkage => :static
 
   pod 'CircleProgrammableWalletSDK'
 
@@ -28,6 +31,9 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+
+      # See this: https://developer.apple.com/forums/thread/725300
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
     end
   end
 end


### PR DESCRIPTION
Unfortunately the sample app is broken with the current Podfile content because it fails to load additional dependencies (e.g. Alamofire).

Updating the Podfile to match the only in README of https://github.com/circlefin/w3s-ios-sdk fixes the issue.